### PR TITLE
switch from manual file parsing to symfony yaml component

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,8 @@
     "require": {
         "silex/silex": "~1.2",
         "symfony/twig-bridge": "~2.6",
-        "symfony/finder": "~2.6"
+        "symfony/finder": "~2.6",
+        "symfony/yaml": "~2.6"
     },
     "require-dev": {
         "symfony/var-dumper": "~2.6"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "dc96a28e553934d38777417164370b3c",
+    "hash": "46b3b465e20c2b10853fa0ceff40ebc8",
     "packages": [
         {
             "name": "pimple/pimple",
@@ -726,6 +726,53 @@
                 }
             ],
             "description": "Symfony Twig Bridge",
+            "homepage": "http://symfony.com",
+            "time": "2015-01-25 04:39:26"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v2.6.4",
+            "target-dir": "Symfony/Component/Yaml",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/Yaml.git",
+                "reference": "60ed7751671113cf1ee7d7778e691642c2e9acd8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/Yaml/zipball/60ed7751671113cf1ee7d7778e691642c2e9acd8",
+                "reference": "60ed7751671113cf1ee7d7778e691642c2e9acd8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Symfony\\Component\\Yaml\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "Symfony Yaml Component",
             "homepage": "http://symfony.com",
             "time": "2015-01-25 04:39:26"
         },

--- a/src/BadgeBatch/SkillFileParser.php
+++ b/src/BadgeBatch/SkillFileParser.php
@@ -3,6 +3,7 @@
 namespace BadgeBatch;
 
 use Symfony\Component\Yaml\Parser;
+use Symfony\Component\Yaml\Exception\ParseException;
 
 class SkillFileParser
 {
@@ -16,12 +17,13 @@ class SkillFileParser
         $parser = new Parser();
         $skills = [];
 
-        // todo might throw Symfony\Component\Yaml\Exception\ParseException
-        //      do we want to catch this here or handle further up
-        $data = $parser->parse($content);
+        try {
+            $data = $parser->parse($content);
+        } catch (ParseException $e) {
+            return [];
+        }
 
         foreach ($data as $skill => $rank) {
-            // todo check for allowed values
             if (! is_string($rank)) {
                 continue;
             }

--- a/src/BadgeBatch/SkillFileParser.php
+++ b/src/BadgeBatch/SkillFileParser.php
@@ -2,6 +2,8 @@
 
 namespace BadgeBatch;
 
+use Symfony\Component\Yaml\Parser;
+
 class SkillFileParser
 {
     /**
@@ -11,19 +13,20 @@ class SkillFileParser
      */
     public function parse($content)
     {
+        $parser = new Parser();
         $skills = [];
-        foreach (explode("\n", $content) as $line) {
-            $line = trim($line);
-            if (! $line) {
+
+        // todo might throw Symfony\Component\Yaml\Exception\ParseException
+        //      do we want to catch this here or handle further up
+        $data = $parser->parse($content);
+
+        foreach ($data as $skill => $rank) {
+            // todo check for allowed values
+            if (! is_string($rank)) {
                 continue;
             }
 
-            $exp = array_filter(array_map('trim', explode(':', $line, 2)));
-            if (count($exp) != 2) {
-                continue;
-            }
-
-            $skills[] = new Skill($exp[0], $exp[1]);
+            $skills[] = new Skill($skill, $rank);
         }
 
         return $skills;


### PR DESCRIPTION
closes #1 

I could also have introduced a ParserInterface and allow both implementations: manual file parsing an sf-yaml. But in this case I thought it would be unnecessary.

Since I have todos in there, this is probably [WIP]. Any thoughts on those todos or the PR in general?
